### PR TITLE
Fix: Mitigate repetitive and empty captions by adjusting generation p…

### DIFF
--- a/src/configs/config.py
+++ b/src/configs/config.py
@@ -258,9 +258,11 @@ class SharedConfigs(object):
                                  help="filter distribution for sampling")
         self.parser.add_argument('--top_p', type=float, default=1,
                                  help="filter distribution for sampling")
-        self.parser.add_argument('--repetition_penalty', type=int, default=1,
+        self.parser.add_argument('--repetition_penalty', type=float, default=1.2,
                                  help="repetition penalty from CTRL paper "
                                  "(https://arxiv.org/abs/1909.05858)")
+        self.parser.add_argument('--no_repeat_ngram_size', type=int, default=2,
+                                 help="If set to int > 0, all ngrams of that size can only occur once.")
         self.parser.add_argument('--length_penalty', type=int, default=1,
                                  help="beam search length penalty")
         

--- a/src/tasks/run_caption_VidSwinBert.py
+++ b/src/tasks/run_caption_VidSwinBert.py
@@ -406,6 +406,7 @@ def test(args, test_dataloader, model, tokenizer, predict_file):
                     "top_k": args.top_k,
                     "top_p": args.top_p,
                     "repetition_penalty": args.repetition_penalty,
+                    "no_repeat_ngram_size": args.no_repeat_ngram_size,
                     "length_penalty": args.length_penalty,
                     "num_return_sequences": args.num_return_sequences,
                     "num_keep_best": args.num_keep_best,
@@ -545,6 +546,9 @@ def get_custom_args(base_config):
     parser.add_argument('--resume_checkpoint', type=str, default='None')
     parser.add_argument('--test_video_fname', type=str, default='None')
     parser.add_argument('--text_encoder_type', type=str, default='bert', choices=['bert', 'roberta'], help="Type of text encoder to use (bert or roberta)")
+    # Add new arguments for generation parameter control
+    parser.add_argument('--repetition_penalty', type=float, default=1.2, help="Repetition penalty for generation.")
+    parser.add_argument('--no_repeat_ngram_size', type=int, default=2, help="If set to int > 0, all ngrams of that size can only occur once.")
     args = base_config.parse_args()
     return args
 

--- a/src/tasks/run_caption_VidSwinBert.py
+++ b/src/tasks/run_caption_VidSwinBert.py
@@ -547,8 +547,6 @@ def get_custom_args(base_config):
     parser.add_argument('--test_video_fname', type=str, default='None')
     parser.add_argument('--text_encoder_type', type=str, default='bert', choices=['bert', 'roberta'], help="Type of text encoder to use (bert or roberta)")
     # Add new arguments for generation parameter control
-    parser.add_argument('--repetition_penalty', type=float, default=1.2, help="Repetition penalty for generation.")
-    parser.add_argument('--no_repeat_ngram_size', type=int, default=2, help="If set to int > 0, all ngrams of that size can only occur once.")
     args = base_config.parse_args()
     return args
 


### PR DESCRIPTION
…arams

The previous default generation parameters (repetition_penalty=1, no no_repeat_ngram_size) were leading to issues where the model would output repetitive single words (e.g., "soccer soccer soccer") or empty strings for video captions.

This commit addresses the issue by:
1. Changing the default `repetition_penalty` from 1 to 1.2 in `src/configs/config.py`. A value greater than 1.0 penalizes token repetition.
2. Introducing `no_repeat_ngram_size` with a default value of 2 in `src/configs/config.py`. This prevents the model from generating the same 2-gram multiple times.
3. Ensuring these parameters are correctly passed to the Hugging Face model's `generate` method in `src/tasks/run_caption_VidSwinBert.py`.

These changes are expected to improve the quality and coherence of generated video captions by reducing repetition and encouraging more diverse output.