### PR TITLE
Fix: Ensure correct output structure during inference

### DIFF
--- a/src/modeling/video_captioning_e2e_vid_swin_bert.py
+++ b/src/modeling/video_captioning_e2e_vid_swin_bert.py
@@ -59,16 +59,32 @@ class VideoTransformer(torch.nn.Module):
                 learn_att.requires_grad = False
             kwargs['attention_mask'][:, -vid_att_len::, -vid_att_len::] = learn_att
 
-        trans_encoder_outputs = self.trans_encoder(*args, **kwargs)
+        outputs = self.trans_encoder(*args, **kwargs)
+
+        # In inference, the fourth output item is the attention scores.
+        if not self.trans_encoder.training:
+            # outputs from BertForImageCaptioning contains loss, logits, hidden_states, attentions
+            # we need to maintain the order of the first two elements.
+            # a list of tensors, which contains sequence_output, pooled_output, (hidden_states), (attentions)
+            trans_encoder_outputs = outputs[0]
+            # In inference, the fourth output item is the attention scores.
+            bert_attentions = outputs[-1]
+            # The format of the output is different in training and inference.
+            if self.learn_mask_enabled:
+                loss_sparsity = self.get_loss_sparsity(learn_att)
+                return trans_encoder_outputs, outputs[1], loss_sparsity, bert_attentions, swin_attentions
+            else:
+                return trans_encoder_outputs, outputs[1], bert_attentions, swin_attentions
+
+        # In training, the output is a tuple of (loss, logits, hidden_states, attentions)
         # trans_encoder_outputs from BertForImageCaptioning.encode_forward now include:
         # (masked_loss, class_logits, *bert_extra_outputs) OR (class_logits, *bert_extra_outputs)
         # where bert_extra_outputs can be (bert_hidden_states, bert_attentions) or (bert_attentions)
         # if config.output_attentions=True and/or config.output_hidden_states=True.
-
-        final_outputs = list(trans_encoder_outputs)
+        final_outputs = list(outputs)
 
         if self.learn_mask_enabled:
-            loss_sparsity = self.get_loss_sparsity(video_attention)  
+            loss_sparsity = self.get_loss_sparsity(video_attention)
             final_outputs.append(loss_sparsity) # Appends to the end of list from trans_encoder
 
         # Append Swin attentions to the final output tuple.
@@ -76,12 +92,6 @@ class VideoTransformer(torch.nn.Module):
         final_outputs.append(swin_attentions)
 
         return tuple(final_outputs)
-        # Return structure example (training, BERT attentions only, learn_mask=True):
-        # (masked_loss, logits, bert_attentions, sparsity_loss, swin_attentions)
-        # Return structure example (eval, BERT attentions only, learn_mask=False):
-        # (logits, bert_attentions, swin_attentions)
-        # If BERT hidden_states also True:
-        # (logits, bert_hidden_states, bert_attentions, swin_attentions)
     
     def get_loss_sparsity(self, video_attention):
         sparsity_loss = 0


### PR DESCRIPTION
The `VideoTransformer`'s `forward` method was modifying the output tuple from the transformer encoder, which caused an `AssertionError` during the generation phase of evaluation. This was because the `past` object (cached hidden states) was being displaced from its expected position in the tuple.

This commit fixes the issue by ensuring that the `past` object is preserved in the correct position in the output tuple during inference, while still allowing for additional outputs like `loss_sparsity` and `swin_attentions` to be returned.