### PR TITLE
Feat: Add debug logging to generation methods

### DIFF
--- a/src/layers/bert/modeling_bert.py
+++ b/src/layers/bert/modeling_bert.py
@@ -1743,6 +1743,16 @@ class BertForImageCaptioning(BertPreTrainedModel):
         return outputs
 
     def prepare_inputs_for_generation(self, curr_ids, past=None):
+        logger.info("Inside prepare_inputs_for_generation")
+        if past is not None:
+            logger.info(f"past is not None, type(past) = {type(past)}")
+            if isinstance(past, tuple) and len(past) > 0:
+                logger.info(f"type(past[0]) = {type(past[0])}")
+                if isinstance(past[0], torch.Tensor):
+                    logger.info(f"past[0].shape = {past[0].shape}")
+        else:
+            logger.info("past is None")
+
         # NOTE: if attention is on, it should be the token used to mask words in training
         mask_token_id = self.mask_token_id
         batch_size = curr_ids.shape[0]


### PR DESCRIPTION
To debug the persistent assertion error during generation, this commit adds logging statements to the `prepare_inputs_for_generation` method in `src/layers/bert/modeling_bert.py`. This logging will provide insight into the `past` object at each step of the generation loop, which will help to identify the root cause of the error.